### PR TITLE
Fix Lucide icon filtering and add missing shadcn/ui identifiers

### DIFF
--- a/src/browser/scope.ts
+++ b/src/browser/scope.ts
@@ -153,9 +153,13 @@ const conflictingNames = new Set([
 ])
 
 // Filter Lucide icons to avoid conflicts with Recharts components
+// Icons are forwardRef objects (typeof "object" with $$typeof), not plain functions
 const LucideIcons = Object.fromEntries(
   Object.entries(AllLucideIcons).filter(
-    ([key]) => !conflictingNames.has(key) && typeof AllLucideIcons[key as keyof typeof AllLucideIcons] === "function"
+    ([key, val]) => !conflictingNames.has(key) && val != null && (
+      typeof val === "function" ||
+      (typeof val === "object" && (val as any).$$typeof != null)
+    )
   )
 )
 

--- a/src/server/component-loader.ts
+++ b/src/server/component-loader.ts
@@ -264,8 +264,21 @@ export function getScopeIdentifiers(): string[] {
   // shadcn/ui components
   const shadcnIdentifiers = [
     "Button", "Card", "CardHeader", "CardTitle", "CardDescription", "CardContent", "CardFooter",
-    "Input", "Label",
-    "Table", "TableHeader", "TableBody", "TableFooter", "TableHead", "TableRow", "TableCell", "TableCaption"
+    "Input", "Textarea", "Label",
+    "Table", "TableHeader", "TableBody", "TableFooter", "TableHead", "TableRow", "TableCell", "TableCaption",
+    "Dialog", "DialogPortal", "DialogOverlay", "DialogClose", "DialogTrigger", "DialogContent",
+    "DialogHeader", "DialogFooter", "DialogTitle", "DialogDescription",
+    "Sheet", "SheetPortal", "SheetOverlay", "SheetTrigger", "SheetClose", "SheetContent",
+    "SheetHeader", "SheetFooter", "SheetTitle", "SheetDescription",
+    "Tabs", "TabsList", "TabsTrigger", "TabsContent",
+    "Accordion", "AccordionItem", "AccordionTrigger", "AccordionContent",
+    "Select", "SelectGroup", "SelectValue", "SelectTrigger", "SelectContent",
+    "SelectLabel", "SelectItem", "SelectSeparator",
+    "Checkbox", "RadioGroup", "RadioGroupItem", "Switch", "Slider",
+    "Badge", "Avatar", "AvatarImage", "AvatarFallback",
+    "Progress", "Skeleton",
+    "Alert", "AlertTitle", "AlertDescription",
+    "Tooltip", "TooltipTrigger", "TooltipContent", "TooltipProvider"
   ]
 
   // Recharts
@@ -280,6 +293,24 @@ export function getScopeIdentifiers(): string[] {
   // Utilities and markdown
   const utilIdentifiers = ["cn", "format", "canvasEmit", "useCanvasState", "Markdown", "remarkGfm"]
 
+  // Lucide icons - dynamically extract from the package to stay in sync with scope.ts
+  let lucideIdentifiers: string[] = []
+  try {
+    const conflicting = new Set([
+      "Table", "LineChart", "BarChart", "PieChart", "AreaChart", "Radar",
+      "ScatterChart", "Brush", "default", "createLucideIcon", "icons"
+    ])
+    const lucide = require("lucide-react")
+    lucideIdentifiers = Object.keys(lucide).filter(
+      (key: string) => !conflicting.has(key) && lucide[key] != null && (
+        typeof lucide[key] === "function" ||
+        (typeof lucide[key] === "object" && lucide[key].$$typeof != null)
+      )
+    )
+  } catch {
+    // Lucide not available server-side; skip
+  }
+
   // Dynamic components from skill directories
   const dynamicComponents = Array.from(components.keys())
 
@@ -288,6 +319,7 @@ export function getScopeIdentifiers(): string[] {
     ...shadcnIdentifiers,
     ...rechartsIdentifiers,
     ...utilIdentifiers,
+    ...lucideIdentifiers,
     ...dynamicComponents
   ]
 }


### PR DESCRIPTION
## Summary

Two related bug fixes for the ESLint validator / scope alignment:

- **Lucide icons silently excluded from scope**: The filter in `scope.ts` checked `typeof === "function"`, but Lucide icons are `forwardRef` objects (`typeof "object"` with `$$typeof`). This meant most icons were available in the import but filtered out before reaching canvas apps. Fixed the filter in both `scope.ts` and `component-loader.ts`.

- **Missing shadcn/ui identifiers in validator**: Many shadcn/ui components (Dialog, Sheet, Tabs, Accordion, Select, Checkbox, RadioGroup, Switch, Slider, Badge, Avatar, Progress, Skeleton, Alert, Tooltip, Textarea) are exported in `scope.ts` but weren't listed in `getScopeIdentifiers()`, causing false ESLint "undefined variable" errors when canvas apps used them.

Also made the Lucide identifier list in `component-loader.ts` dynamic (reads from the package at runtime) so it stays in sync with `scope.ts` automatically instead of requiring manual updates.

## Files changed

- `src/browser/scope.ts` — Fixed Lucide icon filter to include forwardRef objects
- `src/server/component-loader.ts` — Added missing shadcn/ui identifiers + dynamic Lucide extraction